### PR TITLE
Fix DB initialization for newer Flask

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,10 @@ app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 db = SQLAlchemy(app)
 
+# Initialize the database tables when the application starts
+with app.app_context():
+    db.create_all()
+
 class Checklist(db.Model):
     __tablename__ = 'checklists'
     id = db.Column(db.String(32), primary_key=True)
@@ -32,11 +36,6 @@ class ChecklistItem(db.Model):
     completed = db.Column(db.Boolean, default=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
-
-@app.before_first_request
-def create_tables():
-    """Create database tables if they do not exist."""
-    db.create_all()
 
 def generate_checklist_id():
     return secrets.token_urlsafe(16)


### PR DESCRIPTION
## Summary
- create database tables on startup without using deprecated `before_first_request`

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6846d3f7d31c83328d4f6fde6c4a7973