### PR TITLE
Update tab title to match checklist name

### DIFF
--- a/templates/checklist.html
+++ b/templates/checklist.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ checklist.title }} - Collaborative Checklist</title>
+    <title>{{ checklist.title }}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css" rel="stylesheet">
     <style>
@@ -49,9 +49,10 @@
         <div class="card">
             <div class="card-body p-4">
                 <div class="d-flex justify-content-between align-items-center mb-4">
-                    <h1 class="h3 mb-0 checklist-title" 
-                        contenteditable="true" 
-                        data-checklist-id="{{ checklist.id }}">{{ checklist.title }}</h1>
+                    <h1 class="h3 mb-0 checklist-title"
+                        contenteditable="true"
+                        data-checklist-id="{{ checklist.id }}"
+                        data-original-title="{{ checklist.title }}">{{ checklist.title }}</h1>
                     <div class="header-actions">
                         <button class="btn btn-outline-secondary btn-sm" onclick="resetChecklist()">
                             <i class="bi bi-arrow-counterclockwise"></i> Reset All
@@ -98,7 +99,7 @@
         document.querySelector('.checklist-title').addEventListener('blur', async function() {
             const title = this.textContent.trim();
             const checklistId = this.dataset.checklistId;
-            
+
             try {
                 const response = await fetch(`/checklist/${checklistId}/title`, {
                     method: 'PUT',
@@ -109,6 +110,10 @@
                 });
                 
                 if (!response.ok) throw new Error('Failed to update title');
+
+                // Reflect updated title in browser tab
+                document.title = title;
+                this.dataset.originalTitle = title;
             } catch (error) {
                 console.error('Error updating title:', error);
                 this.textContent = this.dataset.originalTitle;


### PR DESCRIPTION
## Summary
- show the checklist name directly in the page title
- remember original title in markup and update tab title when editing

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846da9dc6c083329f986aca62f50a3a